### PR TITLE
make compatible with python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,11 @@ setup(
     platforms=['any'],
     packages=find_packages(),
     include_package_data=True,
-    url='https://github.com/dwkim78/upsilon',
+    url='https://github.com/mrosseel/upsilon',
     license='MIT',
     author='Dae-Won Kim',
     author_email='dwkim78@gmail.com',
-    install_requires=['numpy>=1.9', 'scikit-learn>=0.17', 'scipy>=0.15',
+    install_requires=['numpy>=1.9', 'scikit-learn==0.17', 'scipy>=0.15',
         #'pyfftw>=0.9.2',
     ],
     keywords=['astronomy', 'periodic variables', 'light curves',
@@ -28,7 +28,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.5',
         'Topic :: Scientific/Engineering :: Artificial Intelligence',
         'Topic :: Scientific/Engineering :: Astronomy'
     ]

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     platforms=['any'],
     packages=find_packages(),
     include_package_data=True,
-    url='https://github.com/mrosseel/upsilon',
+    url='https://github.com/dwkim78/upsilon',
     license='MIT',
     author='Dae-Won Kim',
     author_email='dwkim78@gmail.com',

--- a/upsilon/__init__.py
+++ b/upsilon/__init__.py
@@ -3,13 +3,13 @@ __author__ = 'kim'
 try:
     import pyfftw
 
-    print '-------------------'
-    print '| pyFFTW detected |'
-    print '-------------------'
+    print('-------------------')
+    print('| pyFFTW detected |')
+    print('-------------------')
 except:
-    print '-------------------------------'
-    print '* WARNING: No pyFFTW detected *'
-    print '-------------------------------'
+    print('-------------------------------')
+    print('* WARNING: No pyFFTW detected *')
+    print('-------------------------------')
 
 from upsilon.utils import utils
 from upsilon.utils.logger import Logger

--- a/upsilon/datasets/base.py
+++ b/upsilon/datasets/base.py
@@ -53,12 +53,12 @@ def load_rf_model():
 
     import gzip
     try:
-        import cPickle as pickle
+        import pickle as pickle
     except:
         import pickle
 
     module_path = dirname(__file__)
     file_path = join(module_path, 'models/rf.model.sub.github.gz')
-    clf = pickle.load(gzip.open(file_path, 'rb'))
+    clf = pickle.load(gzip.open(file_path, 'rb'), encoding='latin1')
 
     return clf

--- a/upsilon/extract_features/extract_features.py
+++ b/upsilon/extract_features/extract_features.py
@@ -6,10 +6,10 @@ import numpy as np
 import scipy.stats as ss
 from scipy.optimize import leastsq
 
-import period_LS_pyfftw as pLS
+from . import period_LS_pyfftw as pLS
 
-from feature_set import get_feature_set
-from feature_set import get_feature_set_all
+from .feature_set import get_feature_set
+from .feature_set import get_feature_set_all
 
 feature_names_list = get_feature_set()
 feature_names_list_all = get_feature_set_all()
@@ -569,7 +569,7 @@ class ExtractFeatures:
 
         # Get all the names of features.
         all_vars = vars(self)
-        for name in all_vars.keys():
+        for name in list(all_vars.keys()):
             # Omit input variables such as date, mag, err, etc.
             if not (name == 'date' or name == 'mag' or name == 'err'
                     or name == 'n_threads' or name == 'min_period'):
@@ -635,11 +635,11 @@ class ExtractFeatures:
 
         # Get all the names of features.
         all_vars = vars(self)
-        for name in all_vars.keys():
+        for name in list(all_vars.keys()):
             if name in feature_names_list_all:
                 features[name] = all_vars[name]
 
         # Sort by the keys (i.e. feature names).
-        features = OrderedDict(sorted(features.items(), key=lambda t: t[0]))
+        features = OrderedDict(sorted(list(features.items()), key=lambda t: t[0]))
 
         return features

--- a/upsilon/extract_features/feature_set.py
+++ b/upsilon/extract_features/feature_set.py
@@ -50,4 +50,4 @@ def get_feature_set_all():
 
 
 if __name__ == '__main__':
-    print get_feature_set()
+    print(get_feature_set())

--- a/upsilon/extract_features/period_LS_pyfftw.py
+++ b/upsilon/extract_features/period_LS_pyfftw.py
@@ -71,14 +71,14 @@ def __spread__(y, yy, n, x, m):
     """
     nfac = [0, 1, 1, 2, 6, 24, 120, 720, 5040, 40320, 362880]
     if m > 10. :
-        print 'factorial table too small in spread'
+        print('factorial table too small in spread')
         return
 
-    ix = long(x)
+    ix = int(x)
     if x == float(ix): 
         yy[ix] = yy[ix]+y
     else:
-        ilo = long(x - 0.5*float(m) + 1.0)
+        ilo = int(x - 0.5*float(m) + 1.0)
         ilo = min(max(ilo, 1), n - m + 1) 
         ihi = ilo + m - 1
         nden = nfac[m]
@@ -135,21 +135,21 @@ def fasper(x, y, ofac, hifac, n_threads, MACC=4):
             Translation of IDL code (orig. Numerical recipies)
     """
     #Check dimensions of input arrays
-    n = long(len(x))
+    n = int(len(x))
     if n != len(y):
-        print 'Incompatible arrays.'
+        print('Incompatible arrays.')
         return
     
     #print x, y, hifac, ofac
     
     nout = 0.5*ofac*hifac*n
-    nfreqt = long(ofac*hifac*n*MACC)     #Size the FFT as next power
-    nfreq = 64L                         # of 2 above nfreqt.
+    nfreqt = int(ofac*hifac*n*MACC)     #Size the FFT as next power
+    nfreq = 64                         # of 2 above nfreqt.
 
     while nfreq < nfreqt:
         nfreq = 2*nfreq
 
-    ndim = long(2*nfreq)
+    ndim = int(2*nfreq)
     
     #Compute the mean, variance
     ave = y.mean()
@@ -173,7 +173,7 @@ def fasper(x, y, ofac, hifac, n_threads, MACC=4):
     ck = ((x - xmin)*fac) % fndim
     ckk = (2.0*ck) % fndim
     
-    for j in range(0L, n):
+    for j in range(0, n):
         __spread__(y[j] - ave, wk1, ndim, ck[j], MACC)
         __spread__(1.0, wk2, ndim, ckk[j], MACC)
 

--- a/upsilon/extract_features/period_LS_pyfftw.py
+++ b/upsilon/extract_features/period_LS_pyfftw.py
@@ -144,7 +144,7 @@ def fasper(x, y, ofac, hifac, n_threads, MACC=4):
 
     nout = int(0.5*ofac*hifac*n)
     nfreqt = long(ofac*hifac*n*MACC)     #Size the FFT as next power
-    nfreq = 64L                         # of 2 above nfreqt.
+    nfreq = long(64)                         # of 2 above nfreqt.
 
     while nfreq < nfreqt:
         nfreq = 2*nfreq

--- a/upsilon/test/extract_features.py
+++ b/upsilon/test/extract_features.py
@@ -49,7 +49,7 @@ def run():
 
     logger.info('Extracted features:')
     features = e_features.get_features_all()
-    for key, value in features.iteritems():
+    for key, value in list(features.items()):
         logger.info('   %s: %f' % (key, value))
 
     logger.info('Finished')

--- a/upsilon/test/predict.py
+++ b/upsilon/test/predict.py
@@ -42,7 +42,7 @@ def run():
         % len(feature_names_list))
 
     features_all = e_features.get_features()
-    for key, value in features_all.iteritems():
+    for key, value in list(features_all.items()):
         if key != 'n_points':
             logger.info('   %s %s: %f' % ('(+)'
                 if key in feature_names_list else '(-)', key, value))


### PR DESCRIPTION
conversion from python 2 to python 3 (because the rest of my tools are in python 3, didn't want to go back)
- did conversion with 2to3
- fixed pickle issue by adding encoding='latin1'
- restricted scilearn to version 0.17 because the checked-in tree classifier is incompatible with the 0.18 version
